### PR TITLE
Add Dockerfile and fix requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM tensorflow/tensorflow:1.15.5-gpu-py3
+
+RUN apt-get update -y && apt-get install -y python3-dev build-essential wget
+
+COPY . /app
+
+WORKDIR /app
+
+RUN pip install -r requirements.txt
+
+RUN ./download.sh
+
+ENV BIOBERT_DIR=./biobert_v1.1_pubmed
+
+ENV NER_DIR=./datasets/NER/NCBI-disease
+
+ENV OUTPUT_DIR=./ner_outputs
+
+RUN mkdir -p $OUTPUT_DIR

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-tensorflow-gpu==1.15.2   # GPU version of TensorFlow >= 1.11.0. (should be under 2.0.0)
-
+tensorflow-gpu==1.15.5   # GPU version of TensorFlow >= 1.11.0. (should be under 2.0.0)
+numpy==1.18.0
 
 
 # To evaluate RE answers :
-sklearn
-pandas==0.23
+scikit-learn==0.24.2
+pandas==1.1.5
 
 # To evaluate BioASQ answers, your system should be able to execute java codes.
 # Please refer https://github.com/BioASQ/Evaluation-Measures for details.


### PR DESCRIPTION
Hi! 

I recently tried to reproduce the NER results, but it was really hard to set up the system config. The requirements constraints don't work anymore, as any version of numpy > 1.20 returns [this error](https://stackoverflow.com/questions/58479556/notimplementederror-cannot-convert-a-symbolic-tensor-2nd-target0-to-a-numpy) when fine-tuning the model to NER, and the pandas version isn't compatible with the other packages. `scikit-learn` is also a better alternative than `sklearn`, as `sklearn` is only a dummy package and installs the latest version of `scikit-learn`.

Because of that, I updated the requirements and created a Dockerfile. Unfortunately, because the model weights are hosted with Google Drive, I couldn't automate the download of the model weights inside the Dockerfile. 

With both of these modifications, the NER results can be easily reproduced:

1. Pull the official tensorflow-gpu image with `docker pull tensorflow/tensorflow:1.15.5-gpu-py3-jupyter`
2. Download and extract [BioBERT-Base v1.1 (+ PubMed 1M)](https://drive.google.com/file/d/1R84voFKHfWV9xjzeLzWBbmY1uOMYpnyD/view?usp=sharing) inside the biobert repo:

The directory structure should look like this:
```
biobert/
├── biobert_v1.1_pubmed
│   ├── bert_config.json
│   ├── model.ckpt-1000000.data-00000-of-00001
│   ├── model.ckpt-1000000.index
│   ├── model.ckpt-1000000.meta
│   └── vocab.txt
├── biocodes
│   ├── [...]
├── create_pretraining_data.py
├── Dockerfile
├── download.sh
├── extract_features.py
├── figs
│   └── biobert_overview.png
├── __init__.py
├── LICENSE
├── modeling.py
├── modeling_test.py
├── optimization.py
├── optimization_test.py
├── README.md
├── requirements.txt
├── run_classifier.py
├── run_ner.py
├── run_pretraining.py
├── run_qa.py
├── run_re.py
├── sample_text.txt
├── tf_metrics.py
├── tokenization.py
└── tokenization_test.py
```
3. To build the image, run `docker build -t biobert .`
4. To start the image in interactive mode, run `docker run --gpus all -it biobert /bin/bash` (remove `--gpus all` if you want to use your CPU instead of GPU)

In the interactive mode, you can use `run_ner.py` and `biocodes/ner_detokenize.py` without problems, and I figured that this might be useful if someone else wants to reproduce the results or develop something on top of BioBERT 